### PR TITLE
get llvm 19 working on MacOS

### DIFF
--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -68,6 +68,7 @@ else()
   FIND_AND_ADD_CLANG_LIB(clangToolingCore)
   FIND_AND_ADD_CLANG_LIB(clangExtractAPI)
   FIND_AND_ADD_CLANG_LIB(clangSupport)
+  FIND_AND_ADD_CLANG_LIB(clangInstallAPI)
 endif()
 
 if (MSVC)

--- a/lib/std/zig/system/darwin/macos.zig
+++ b/lib/std/zig/system/darwin/macos.zig
@@ -415,15 +415,15 @@ pub fn detectNativeCpuAndFeatures() ?Target.Cpu {
                 .ARM_VORTEX_TEMPEST => &Target.aarch64.cpu.apple_a12,
                 .ARM_MONSOON_MISTRAL => &Target.aarch64.cpu.apple_a11,
                 .ARM_HURRICANE => &Target.aarch64.cpu.apple_a10,
-                .ARM_TWISTER => &Target.aarch64.cpu.apple_a9,
-                .ARM_TYPHOON => &Target.aarch64.cpu.apple_a8,
-                .ARM_CYCLONE => &Target.aarch64.cpu.cyclone,
-                else => return null,
+                .ARM_TWISTER => &Target.aarch64.cpu.apple_a7, // a9
+                .ARM_TYPHOON => &Target.aarch64.cpu.apple_a7, // a8
+                .ARM_CYCLONE => &Target.aarch64.cpu.apple_a7, // cyclone
                 .ARM_COLL => &Target.aarch64.cpu.apple_a17,
-                .ARM_IBIZA => &Target.aarch64.cpu.apple_m3, // base
-                .ARM_LOBOS => &Target.aarch64.cpu.apple_m3, // pro
-                .ARM_PALMA => &Target.aarch64.cpu.apple_m3, // max
-                // .ARM_DONAN => &Target.aarch64.cpu.apple_m4, // decl not available until llvm 19
+                .ARM_IBIZA => &Target.aarch64.cpu.apple_a16, // m3 base
+                .ARM_LOBOS => &Target.aarch64.cpu.apple_a16, // m3 pro
+                .ARM_PALMA => &Target.aarch64.cpu.apple_a16, // m3 max
+                .ARM_DONAN => &Target.aarch64.cpu.apple_m4,
+                else => return null,
             };
 
             return Target.Cpu{

--- a/src/clang.zig
+++ b/src/clang.zig
@@ -2126,6 +2126,8 @@ pub const CallingConv = enum(c_int) {
     AArch64SVEPCS,
     AMDGPUKernelCall,
     M68kRTD,
+    PreserveNone,
+    RISCVVectorCall,
 };
 
 pub const StorageClass = enum(c_int) {

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -208,6 +208,8 @@ void ZigClang_detect_enum_CK(clang::CastKind x) {
         case clang::CK_UserDefinedConversion:
         case clang::CK_VectorSplat:
         case clang::CK_ZeroToOCLOpaqueType:
+        case clang::CK_HLSLVectorTruncation:
+        case clang::CK_HLSLArrayRValue:
             break;
     }
 };
@@ -1607,6 +1609,7 @@ void ZigClang_detect_enum_BuiltinTypeKind(clang::BuiltinType::Kind x) {
         case clang::BuiltinType::IncompleteMatrixIdx:
         case clang::BuiltinType::OMPArrayShaping:
         case clang::BuiltinType::OMPIterator:
+        case clang::BuiltinType::ArraySection:
             break;
     }
 }

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2136,6 +2136,8 @@ void ZigClang_detect_enum_CallingConv(clang::CallingConv x) {
         case clang::CC_AArch64SVEPCS:
         case clang::CC_AMDGPUKernelCall:
         case clang::CC_M68kRTD:
+        case clang::CC_PreserveNone:
+        case clang::CC_RISCVVectorCall:
             break;
     }
 }
@@ -2162,6 +2164,8 @@ static_assert((clang::CallingConv)ZigClangCallingConv_AArch64VectorCall == clang
 static_assert((clang::CallingConv)ZigClangCallingConv_AArch64SVEPCS == clang::CC_AArch64SVEPCS, "");
 static_assert((clang::CallingConv)ZigClangCallingConv_AMDGPUKernelCall == clang::CC_AMDGPUKernelCall, "");
 static_assert((clang::CallingConv)ZigClangCallingConv_M68kRTD == clang::CC_M68kRTD, "");
+static_assert((clang::CallingConv)ZigClangCallingConv_PreserveNone == clang::CC_PreserveNone, "");
+static_assert((clang::CallingConv)ZigClangCallingConv_RISCVVectorCall == clang::CC_RISCVVectorCall, "");
 
 void ZigClang_detect_enum_StorageClass(clang::StorageClass x) {
     switch (x) {

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -1231,6 +1231,8 @@ enum ZigClangCallingConv {
     ZigClangCallingConv_AArch64SVEPCS,
     ZigClangCallingConv_AMDGPUKernelCall,
     ZigClangCallingConv_M68kRTD,
+    ZigClangCallingConv_PreserveNone,
+    ZigClangCallingConv_RISCVVectorCall,
 };
 
 enum ZigClangStorageClass {


### PR DESCRIPTION
you can discard the ProcessorAlias patch if you have a better solution :)